### PR TITLE
Avoid repeated authentication when valid token is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,6 @@ db = ibc.get_info(data_type="volume_maps")
 # Keep statistic maps for sub-08, for task-Discount
 filtered_db = ibc.filter_data(db, subject_list=["08"], task_list=["Discount"])
 
-# Authenticate with EBRAINS before downloading
-# Returns a link that takes you to EBRAINS login page and stores an access token locally
-ibc.authenticate()
-
 # Download all statistic maps for sub-08, task-Discount 
 # Also creates ibc_data/downloaded_volume_maps.csv 
 # which contains local file paths and time of download

--- a/examples/example.py
+++ b/examples/example.py
@@ -7,10 +7,6 @@ db = ibc.get_info(data_type="volume_maps")
 # Keep statistic maps for sub-08, for task-Discount
 filtered_db = ibc.filter_data(db, subject_list=["08"], task_list=["Discount"])
 
-# Authenticate with EBRAINS before downloading
-# Returns a link that takes you to EBRAINS login page and stores an access token locally
-ibc.authenticate()
-
 # Download all statistic maps for sub-08, task-Discount
 # Also creates ibc_data/downloaded_volume_maps.csv
 # which contains local file paths and time of download

--- a/examples/get_data.ipynb
+++ b/examples/get_data.ipynb
@@ -28,7 +28,8 @@
      "text": [
       "[siibra:INFO] Version: 0.4a47\n",
       "[siibra:WARNING] This is a development release. Use at your own risk.\n",
-      "[siibra:INFO] Please file bugs and issues at https://github.com/FZJ-INM1-BDA/siibra-python.\n"
+      "[siibra:INFO] Please file bugs and issues at https://github.com/FZJ-INM1-BDA/siibra-python.\n",
+      "[siibra:INFO] Clearing siibra cache at /home/himanshu/.cache/siibra.retrieval\n"
      ]
     }
    ],
@@ -486,6 +487,13 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found 12 files for subjects ['08'] and tasks ['Discount'].\n"
+     ]
+    },
+    {
      "data": {
       "text/html": [
        "<div>\n",
@@ -802,34 +810,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now before we download these files, we need to authenticate with EBRAINS. This will return a link that takes you to EBRAINS login page and stores an access token locally.\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "***\n",
-      "To continue, please go to https://iam.ebrains.eu/auth/realms/hbp/device?user_code=LGDW-XTRE\n",
-      "***\n",
-      "ebrains token successfuly set.\n"
-     ]
-    }
-   ],
-   "source": [
-    "ibc.authenticate()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Now we are ready to download the few selected maps that we filtered.\n",
     "\n",
     "The following will save the requested maps under\n",
@@ -839,15 +819,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found 12 files to download.\n",
+      "***\n",
+      "To continue, please go to https://iam.ebrains.eu/auth/realms/hbp/device?user_code=UFKZ-XXQU\n",
+      "***\n"
+     ]
+    },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[siibra:INFO] 139625 objects found for dataset ad04f919-7dcc-48d9-864a-d7b62af3d49d returned.\n",
-      "12it [00:01, 11.22it/s]\n"
+      "[siibra:INFO] 139625 objects found for dataset ad04f919-7dcc-48d9-864a-d7b62af3d49d returned.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ebrains token successfuly set.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Overall Progress:   0%|\u001b[32m                                                                                                                                                                                                                                                                       \u001b[0m| 0/12 [00:00<?, ?it/s]\u001b[0m\u001b[A\n",
+      "Overall Progress:  17%|\u001b[32m██████████████████████████████████████████▌                                                                                                                                                                                                                    \u001b[0m| 2/12 [00:00<00:00, 12.46it/s]\u001b[0m\u001b[A\n",
+      "Overall Progress:  33%|\u001b[32m█████████████████████████████████████████████████████████████████████████████████████                                                                                                                                                                          \u001b[0m| 4/12 [00:00<00:00, 12.26it/s]\u001b[0m\u001b[A\n",
+      "Overall Progress:  50%|\u001b[32m███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▌                                                                                                                               \u001b[0m| 6/12 [00:00<00:00, 11.73it/s]\u001b[0m\u001b[A\n",
+      "Overall Progress:  67%|\u001b[32m██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████                                                                                     \u001b[0m| 8/12 [00:00<00:00, 11.80it/s]\u001b[0m\u001b[A\n",
+      "Overall Progress:  83%|\u001b[32m███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▋                                          \u001b[0m| 10/12 [00:00<00:00, 11.94it/s]\u001b[0m\u001b[A\n",
+      "Overall Progress: 100%|\u001b[32m██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████\u001b[0m| 12/12 [00:01<00:00, 11.97it/s]\u001b[0m\u001b[A\n"
      ]
     },
     {
@@ -886,62 +896,62 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>ibc_data/volume_maps/sub-08/ses-27/sub-08_ses-...</td>\n",
-       "      <td>2023-09-18 17:37:15.588770</td>\n",
+       "      <td>2023-10-05 17:23:53.472528</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>ibc_data/volume_maps/sub-08/ses-27/sub-08_ses-...</td>\n",
-       "      <td>2023-09-18 17:37:15.765652</td>\n",
+       "      <td>2023-10-05 17:23:53.628380</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>ibc_data/volume_maps/sub-08/ses-27/sub-08_ses-...</td>\n",
-       "      <td>2023-09-18 17:37:15.772669</td>\n",
+       "      <td>2023-10-05 17:23:53.634523</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>ibc_data/volume_maps/sub-08/ses-27/sub-08_ses-...</td>\n",
-       "      <td>2023-09-18 17:37:15.944780</td>\n",
+       "      <td>2023-10-05 17:23:53.793226</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>ibc_data/volume_maps/sub-08/ses-27/sub-08_ses-...</td>\n",
-       "      <td>2023-09-18 17:37:15.949580</td>\n",
+       "      <td>2023-10-05 17:23:53.799418</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
        "      <td>ibc_data/volume_maps/sub-08/ses-27/sub-08_ses-...</td>\n",
-       "      <td>2023-09-18 17:37:16.116007</td>\n",
+       "      <td>2023-10-05 17:23:53.972341</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
        "      <td>ibc_data/volume_maps/sub-08/ses-27/sub-08_ses-...</td>\n",
-       "      <td>2023-09-18 17:37:16.121902</td>\n",
+       "      <td>2023-10-05 17:23:53.979429</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
        "      <td>ibc_data/volume_maps/sub-08/ses-27/sub-08_ses-...</td>\n",
-       "      <td>2023-09-18 17:37:16.298023</td>\n",
+       "      <td>2023-10-05 17:23:54.140314</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>8</th>\n",
        "      <td>ibc_data/volume_maps/sub-08/ses-27/sub-08_ses-...</td>\n",
-       "      <td>2023-09-18 17:37:16.302662</td>\n",
+       "      <td>2023-10-05 17:23:54.146809</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>9</th>\n",
        "      <td>ibc_data/volume_maps/sub-08/ses-27/sub-08_ses-...</td>\n",
-       "      <td>2023-09-18 17:37:16.471236</td>\n",
+       "      <td>2023-10-05 17:23:54.304385</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>10</th>\n",
        "      <td>ibc_data/volume_maps/sub-08/ses-27/sub-08_ses-...</td>\n",
-       "      <td>2023-09-18 17:37:16.476903</td>\n",
+       "      <td>2023-10-05 17:23:54.310566</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>11</th>\n",
        "      <td>ibc_data/volume_maps/sub-08/ses-27/sub-08_ses-...</td>\n",
-       "      <td>2023-09-18 17:37:16.651207</td>\n",
+       "      <td>2023-10-05 17:23:54.468429</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -963,21 +973,21 @@
        "11  ibc_data/volume_maps/sub-08/ses-27/sub-08_ses-...   \n",
        "\n",
        "                 downloaded_on  \n",
-       "0   2023-09-18 17:37:15.588770  \n",
-       "1   2023-09-18 17:37:15.765652  \n",
-       "2   2023-09-18 17:37:15.772669  \n",
-       "3   2023-09-18 17:37:15.944780  \n",
-       "4   2023-09-18 17:37:15.949580  \n",
-       "5   2023-09-18 17:37:16.116007  \n",
-       "6   2023-09-18 17:37:16.121902  \n",
-       "7   2023-09-18 17:37:16.298023  \n",
-       "8   2023-09-18 17:37:16.302662  \n",
-       "9   2023-09-18 17:37:16.471236  \n",
-       "10  2023-09-18 17:37:16.476903  \n",
-       "11  2023-09-18 17:37:16.651207  "
+       "0   2023-10-05 17:23:53.472528  \n",
+       "1   2023-10-05 17:23:53.628380  \n",
+       "2   2023-10-05 17:23:53.634523  \n",
+       "3   2023-10-05 17:23:53.793226  \n",
+       "4   2023-10-05 17:23:53.799418  \n",
+       "5   2023-10-05 17:23:53.972341  \n",
+       "6   2023-10-05 17:23:53.979429  \n",
+       "7   2023-10-05 17:23:54.140314  \n",
+       "8   2023-10-05 17:23:54.146809  \n",
+       "9   2023-10-05 17:23:54.304385  \n",
+       "10  2023-10-05 17:23:54.310566  \n",
+       "11  2023-10-05 17:23:54.468429  "
       ]
      },
-     "execution_count": 7,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -996,16 +1006,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<nilearn.plotting.displays._slicers.OrthoSlicer at 0x7f341bf5fb80>"
+       "<nilearn.plotting.displays._slicers.OrthoSlicer at 0x7f7bdd436bb0>"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     },

--- a/src/ibc_api/utils.py
+++ b/src/ibc_api/utils.py
@@ -38,7 +38,7 @@ def _authenticate(token_dir=TOKEN_ROOT):
     """
 
     # read the token file
-    token_file = os.path.join(token_dir, "token1")
+    token_file = os.path.join(token_dir, "token")
     if os.path.exists(token_file):
         with open(token_file, "r") as f:
             token = f.read()


### PR DESCRIPTION
This PR fixes #8 by:
- automatically fetching a token during download step, without user's explicit call
- saving the fetched token locally and reusing it in subsequent calls of `download_data`
- only asking to fetch a new token once the previous one has expired  