### PR TITLE
Moving away from EbrainsHdgConnector, to ebrains-drive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ src/ibc-api
 ibc_data
 .ipynb_checkpoints
 src/ibc_api/data/token
+src/ibc_api/cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,4 +12,5 @@ dependencies = [
     "pandas",
     "tqdm",
     "joblib",
+    "ebrains_drive",
 ]

--- a/src/ibc_api/scripts/create_db.py
+++ b/src/ibc_api/scripts/create_db.py
@@ -1,84 +1,116 @@
 """Script to create the database from the raw, preprocessed, volume maps and surface maps
 data on EBRAINS."""
 
-# import libraries
-import pandas as pd
+import argparse
 import os
+
 import ibc_api.utils as ibc
-from ibc_api.metadata import fetch_metadata, _find_latest_version
+import pandas as pd
 from bids.layout import parse_file_entities
+from ebrains_drive import BucketApiClient
+from ibc_api.metadata import select_dataset
+from siibra.retrieval.requests import EbrainsRequest
+from tqdm import tqdm
 
 datasets = ["raw", "preprocessed", "volume_maps", "surface_maps"]
 
-ibc._authenticate()
-for dataset in datasets:
-    for version in range(1, 6):
-        # Get EBRAINS metadata about the dataset
-        try:
-            ebrains_data = ibc._connect_ebrains(dataset, version=version)
-        except (ValueError, IndexError) as error:
-            print(error)
-            print(f"skipping dataset {dataset}, version {version}")
-            continue
-        try:
-            root_dir = ebrains_data.prefix.strip("/")
-        except AttributeError:
-            root_dir = ""
-        # Get the file names and other info as dataframes
-        ebrains_df = pd.DataFrame(ebrains_data.__dict__["_files"])
-        filenames = ebrains_df["name"].tolist()
-        # parse filenames using pybids to get all the entities
-        bids_entities = []
-        for file in filenames:
-            bids_entity = parse_file_entities(
-                file,
-                include_unmatched=True,
-                config=os.path.join(
-                    os.path.dirname(__file__), "ibc_config.json"
-                ),
+
+def main(dataset_types):
+    """Main function to create the database containing the available data in
+    each Ebrains collection.
+    Parameters
+    ----------
+    dataset_types : list of str
+        list of dataset types to process, could be one or more of
+        'volume_maps', 'surface_maps', 'preprocessed', 'raw'
+    """
+    EbrainsRequest.fetch_token()
+    client = BucketApiClient(token=EbrainsRequest._KG_API_TOKEN)
+
+    for dataset_type in tqdm(dataset_types, desc="Dataset types"):
+        for version in tqdm(
+            range(1, 6), desc=f"{dataset_type} versions", leave=False
+        ):
+            # Get EBRAINS metadata about the dataset
+            try:
+                dataset = select_dataset(dataset_type, version=version)
+            except (ValueError, IndexError) as error:
+                tqdm.write(str(error))
+                tqdm.write(
+                    f"skipping dataset {dataset_type}, version {version}"
+                )
+                continue
+
+            dataset_id = dataset["id"]
+            bucket = client.buckets.get_dataset(
+                dataset_id, request_access=True
             )
-            bids_entities.append(bids_entity)
-        # convert the list of dictionaries with bids entities to a dataframe
-        bids_df = pd.DataFrame(bids_entities)
-        # remove rows with empty path
-        bids_df = bids_df.dropna(how="all")
-        # add a column with the file sizes in MB
-        bids_df["megabytes"] = ebrains_df["bytes"].astype(int).div(1024**2)
-        # add a column with the dataset name
-        bids_df["dataset"] = [dataset] * len(bids_df)
-        infer_root_dir = ebrains_df["name"].str.split("/").str[0].unique()[0]
 
-        if infer_root_dir == root_dir:
-            # add a column with the file path without the root directory
-            path = ebrains_df["name"].str.split("/").str[1:].str.join("/")
-        else:
-            # add a column with the file path
-            path = ebrains_df["name"]
+            if bucket is None:
+                tqdm.write(f"dataset {dataset_id} not found, skipping")
+                continue
 
-        breakpoint()
+            rows = []
+            for item in tqdm(
+                bucket.ls(),
+                desc=f"Files in {dataset_type} v{version}",
+                leave=False,
+            ):
+                # parse filenames using pybids to get all the entities
+                bids_entity = parse_file_entities(
+                    item.name,
+                    include_unmatched=True,
+                    config=os.path.join(
+                        os.path.dirname(__file__), "ibc_config.json"
+                    ),
+                )
+                path = "/".join(item.name.split("/")[1:])
+                root_dir_series = item.name.split("/")[0]
+                row = {
+                    **bids_entity,
+                    "megabytes": item.bytes / (1024**2),
+                    "dataset": dataset_type,
+                    "path": path,
+                    "root_series": root_dir_series,
+                }
+                rows.append(row)
 
-        root_dir_series = ebrains_df["name"].str.split("/").str[0]
-        bids_df["path"] = path
-        # separate surface maps and volume maps in different csv files
-        if dataset == "surface_maps":
-            mask = (
-                root_dir_series == "resulting_smooth_maps_surface"
-            ) & bids_df["extension"].isin([".gii", ".json"])
-            bids_df = bids_df[mask]
-        # there are some files with .gii extension in the volume maps folder
-        # filtering them out
-        elif dataset == "volume_maps":
-            mask = (root_dir_series == "resulting_smooth_maps") & bids_df[
-                "extension"
-            ].isin([".nii.gz", ".json"])
-            bids_df = bids_df[mask]
-        bids_df = bids_df.reset_index(drop=True)
-        # create a csv file with the bids entities
-        csv_file = os.path.join(
-            os.path.dirname(__file__),
-            "..",
-            "data",
-            f"{dataset}_v{version}.csv",
-        )
-        bids_df.to_csv(csv_file)
-        print(f"{csv_file} created!")
+            df = pd.DataFrame(rows)
+
+            # separate surface maps and volume maps in different csv files
+            if dataset_type == "surface_maps":
+                mask = (
+                    df["root_series"] == "resulting_smooth_maps_surface"
+                ) & df["extension"].isin([".gii", ".json"])
+                df = df[mask]
+            # there are some files with .gii extension in the volume maps folder
+            # filtering them out
+            elif dataset_type == "volume_maps":
+                mask = (df["root_series"] == "resulting_smooth_maps") & df[
+                    "extension"
+                ].isin([".nii.gz", ".json"])
+                df = df[mask]
+
+            bids_df = df.drop(columns=["root_series"])
+            # create a csv file with the bids entities
+            csv_file = os.path.join(
+                os.path.dirname(__file__),
+                "..",
+                "data",
+                f"{dataset_type}_v{version}.csv",
+            )
+            bids_df.to_csv(csv_file)
+            tqdm.write(f"{csv_file} created!")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--dataset_type",
+        choices=datasets,
+        nargs="+",  # allows one or more values
+        default=datasets,
+        help="Dataset type(s) to process. Defaults to all.",
+    )
+    args = parser.parse_args()
+    main(args.dataset_type)

--- a/src/ibc_api/utils.py
+++ b/src/ibc_api/utils.py
@@ -95,7 +95,7 @@ def _connect_ebrains(data_type="volume_maps", metadata=METADATA, version=None):
     EbrainsRequest.fetch_token()
     # use the token to create a client and get a data bucket
     client = BucketApiClient(token=EbrainsRequest._KG_API_TOKEN)
-    bucket = client.buckets.get_dataset(dataset_id)
+    bucket = client.buckets.get_dataset(dataset_id, request_access=True)
 
     return bucket
 

--- a/src/ibc_api/utils.py
+++ b/src/ibc_api/utils.py
@@ -1,6 +1,7 @@
 """API to fetch IBC data from EBRAINS via Human Data Gateway using siibra."""
 
 # %$
+import gzip
 import json
 import os
 from datetime import datetime
@@ -8,12 +9,16 @@ from datetime import datetime
 import nibabel
 import pandas as pd
 import siibra
-from joblib import Memory, Parallel, delayed
+from ebrains_drive import BucketApiClient
+from joblib import Memory
 from siibra.retrieval.cache import CACHE
-from siibra.retrieval.repositories import EbrainsHdgConnector
-from siibra.retrieval.requests import EbrainsRequest, SiibraHttpRequestError
+from siibra.retrieval.requests import EbrainsRequest
+from tqdm import tqdm
 
 from . import metadata as md
+
+# enable device flow for authentication
+os.environ["SIIBRA_ENABLE_DEVICE_FLOW"] = "1"
 
 # clear cache
 CACHE.clear()
@@ -80,28 +85,19 @@ def _connect_ebrains(data_type="volume_maps", metadata=METADATA, version=None):
 
     Returns
     -------
-    EbrainsHdgConnector
-        connector to the dataset
+    bucket: siibra.retrieval.buckets.DatasetBucket
+        a bucket object corresponding to the requested dataset
     """
     # get the dataset id
     dataset = md.select_dataset(data_type, metadata, version)
     dataset_id = dataset["id"]
+    # fetch token and connect to ebrains
+    EbrainsRequest.fetch_token()
+    # use the token to create a client and get a data bucket
+    client = BucketApiClient(token=EbrainsRequest._KG_API_TOKEN)
+    bucket = client.buckets.get_dataset(dataset_id)
 
-    # authenticate with ebrains
-    token_file = _authenticate()
-
-    try:
-        return EbrainsHdgConnector(dataset_id)
-    except AttributeError:
-        raise ValueError(
-            f"Unable to fetch dataset {data_type}, version {version} from EBRAINS."
-        )
-    except SiibraHttpRequestError:
-        print("Saved token is invalid. Fetching a new token.")
-        # delete the token file
-        os.remove(token_file)
-        # try connecting again
-        return _connect_ebrains(data_type, metadata, version)
+    return bucket
 
 
 def _create_root_dir(dir_path=None):
@@ -168,7 +164,9 @@ def _is_empty_db(db):
     return db is None or db.empty or len(db) == 0
 
 
-def get_info(data_type="volume_maps", save_to=None, metadata=METADATA):
+def get_info(
+    data_type="volume_maps", save_to=None, metadata=METADATA, version=None
+):
     """Fetch a csv file describing each file in a given IBC dataset on EBRAINS.
 
     Parameters
@@ -179,20 +177,41 @@ def get_info(data_type="volume_maps", save_to=None, metadata=METADATA):
     save_as : str or None, optional
         filename to save this csv as, by default None, if None saves as
         "ibc_data/available_{data_type}.csv"
+    metadata : dict, optional
+        dictionary object containing version info, dataset ids etc, by default
+        METADATA
+    version : int or None, optional
+        version of the dataset to select, starts from 1, by default None, if
+        None selects the latest version
 
     Returns
     -------
     pandas.DataFrame
         dataframe with information about each file in the dataset
     """
-
     datasets = metadata[data_type]
     latest_idx = md._find_latest_version(datasets)
 
+    # if version is specified, only try that version
+    # otherwise try from latest to oldest
+    if version is not None:
+        # find the index corresponding to the requested version
+        version_indices = [
+            i for i, d in enumerate(datasets) if d["version"] == version
+        ]
+        if not version_indices:
+            raise ValueError(
+                f"Version {version} not found for dataset {data_type}."
+            )
+        version_range = version_indices  # only one version to try
+    else:
+        version_range = range(latest_idx, -1, -1)
+
     last_exception = None
+    db = None
 
     # Try from latest version → older versions
-    for version_idx in range(latest_idx, -1, -1):
+    for version_idx in version_range:
         # fetch the information corresponding to this version
         dataset = datasets[version_idx]
         db_file = md.fetch_remote_file(dataset["db_file"])
@@ -315,15 +334,17 @@ def get_file_paths(db, metadata=METADATA, save_to_dir=None):
     return remote_file_names, local_file_names
 
 
-def _update_local_db(db_file, files_data):
+def _update_local_db(db_file, downloaded_file, download_time):
     """Update the local database of downloaded files.
 
     Parameters
     ----------
     db_file : str
         path to the local database file
-     files_data : list of tuples
-        list of tuples where each tuple contains (file_name, file_time)
+    downloaded_file : str
+        path to the downloaded file
+    download_time : datetime
+        time at which the file was downloaded
 
     Returns
     -------
@@ -342,71 +363,83 @@ def _update_local_db(db_file, files_data):
             pd.errors.ParserError,
             FileNotFoundError,
         ):
-            print("Empty database file. Creating a new one.")
+            tqdm.write("Empty database file. Creating a new one.")
             db = pd.DataFrame(columns=["local_path", "downloaded_on"])
 
     downloaded_db = pd.DataFrame(
-        files_data, columns=["local_path", "downloaded_on"]
+        {"local_path": [downloaded_file], "downloaded_on": [download_time]}
     )
-
-    new_db = pd.concat([db, downloaded_db], ignore_index=True)
-    new_db.reset_index(drop=True, inplace=True)
-    # save the database
-    new_db.to_csv(db_file, index=False)
+    db = pd.concat([db, downloaded_db], ignore_index=True)
+    db.to_csv(db_file, index=False)
 
     return db
 
 
-def _write_file(file, data):
+def _write_file(src_file, dst_file, data):
     """Write data to a file.
 
     Parameters
     ----------
-    file : str
-        path to the file to write to
-    data : data fetched from ebrains
+    src_file : str
+       path to the source file on ebrains
+    dst_file : str
+        path to save the file to locally
+    data : bytes
         data to write to the file
 
     Returns
     -------
-    file: str
+    dts_file: str
         path to the written
+
+    Raises
+    ------
+    ValueError
+        if the file type is not supported
+    nibabel.filebasedimages.ImageFileError
+        if the image data is corrupt or cannot be read
     """
-    # check file type and write accordingly
-    if type(data) == nibabel.nifti1.Nifti1Image:
-        nibabel.save(data, file)
-    elif type(data) == nibabel.gifti.gifti.GiftiImage:
-        nibabel.save(data, file, mode="compat")
-    elif type(data) == pd.core.frame.DataFrame:
-        if file.endswith(".csv"):
-            data.to_csv(file, index=False)
-        elif file.endswith(".tsv"):
-            data.to_csv(file, index=False, sep="\t")
-        else:
-            raise ValueError(
-                f"File type not supported for {file}. Only .csv and .tsv are supported."
-            )
-    elif type(data) == dict:
-        with open(file, "w") as f:
-            json.dump(data, f)
-    elif type(data) == bytes:
-        if file.endswith(".bvec") or file.endswith(".bval"):
-            with open(file, "wb") as f:
+    try:
+        if src_file.endswith(".nii.gz") or src_file.endswith(".nii"):
+            img = nibabel.Nifti1Image.from_bytes(gzip.decompress(data))
+            nibabel.save(img, dst_file)
+        elif src_file.endswith(".gii"):
+            img = nibabel.gifti.gifti.GiftiImage.from_bytes(data)
+            nibabel.save(img, dst_file, mode="compat")
+        elif src_file.endswith(".csv") or src_file.endswith(".tsv"):
+            # read the data as a dataframe and save it
+            df = pd.read_csv(io.StringIO(data.decode("utf-8")))
+            if dst_file.endswith(".csv"):
+                df.to_csv(dst_file, index=False)
+            elif dst_file.endswith(".tsv"):
+                df.to_csv(dst_file, index=False, sep="\t")
+            else:
+                raise ValueError(
+                    f"File type not supported for {dst_file}. Only .csv and .tsv are supported."
+                )
+        elif src_file.endswith(".json"):
+            # read the data as a dictionary and save it
+            dict_data = json.loads(data.decode("utf-8"))
+            with open(dst_file, "w") as f:
+                json.dump(dict_data, f)
+        elif src_file.endswith(".bvec") or src_file.endswith(".bval"):
+            with open(dst_file, "wb") as f:
                 f.write(data)
             f.close()
         else:
             raise ValueError(
-                f"Don't know how to save file {file} of type {type(data)}"
+                f"Don't know how to save file {dst_file} of type {type(data)}"
             )
-    else:
-        raise ValueError(
-            f"Don't know how to save file {file} of type {type(data)}"
-        )
+    except gzip.BadGzipFile as e:
+        raise gzip.BadGzipFile(f"Failed to decompress {src_file}: {e}") from e
+    except (UnicodeDecodeError, json.JSONDecodeError) as e:
+        raise ValueError(f"Failed to decode {src_file}: {e}") from e
+    except Exception as e:
+        raise RuntimeError(f"Unexpected error writing {dst_file}: {e}") from e
 
-    return file
+    return dst_file
 
 
-@memory.cache
 def _download_file(src_file, dst_file, connector):
     """Download a file from ebrains.
 
@@ -416,30 +449,45 @@ def _download_file(src_file, dst_file, connector):
         path to the file on ebrains
     dst_file : str
         path to save the file to locally
-    connector : EbrainsHdgConnector
+    connector : Ebrains connector object
         connector to the IBC dataset on ebrains
 
     Returns
     -------
-    str, datetime
-        path to the downloaded file and time at which it was downloaded
+    str
+        path to the downloaded file
+
+    Raises
+    ------
+    RuntimeError
+        if the file cannot be downloaded due to an unexpected error
+    OSError
+        if the destination directory cannot be created
     """
-    # CACHE.run_maintenance()
-    if not os.path.exists(dst_file):
-        # load the file from ebrains
-        src_data = connector.get(src_file)
+    if os.path.exists(dst_file):
+        tqdm.write(f"File {dst_file} already exists, skipping download.")
+        return dst_file
+
+    try:
+        f = connector.get_file(src_file)
+    except Exception as e:
+        raise RuntimeError(
+            f"Failed to fetch {src_file} from EBRAINS: {e}"
+        ) from e
+
+    try:
         # make sure the directory exists
         dst_file_dir = os.path.split(dst_file)[0]
         os.makedirs(dst_file_dir, exist_ok=True)
-        # save the file locally
-        dst_file = _write_file(dst_file, src_data)
-        return dst_file
-    else:
-        print(f"File {dst_file} already exists, skipping download.")
-        return dst_file
+    except OSError as e:
+        raise OSError(f"Failed to create directory {dst_file_dir}: {e}") from e
+
+    # save the file locally
+    dst_file = _write_file(src_file, dst_file, f.get_content())
+    return dst_file
 
 
-def download_data(db, n_jobs=2, save_to=None):
+def download_data(db, save_to=None):
     """Download the files in a (filtered) dataframe.
 
     Parameters
@@ -447,9 +495,6 @@ def download_data(db, n_jobs=2, save_to=None):
     db : pandas.DataFrame
         dataframe with information about files in the dataset, ideally a subset
         of the full dataset
-    n_jobs : int, optional
-        number of parallel jobs to run, by default 2. -1 would use all the CPUs.
-        See: https://joblib.readthedocs.io/en/latest/generated/joblib.Parallel.html
     save_to : str, optional
         where to save the data, by default None, in which case the data is
         saved in a directory called "ibc_data" in the current working directory
@@ -458,12 +503,20 @@ def download_data(db, n_jobs=2, save_to=None):
     -------
     pandas.DataFrame
         dataframe with downloaded file names and times from the dataset
+
+    Raises
+    ------
+    ValueError
+        if the input dataframe is empty or missing required columns
+    RuntimeError
+        if a file fails to download after retries
     """
     # make sure the dataframe is not empty
     db_length = len(db)
     if db_length == 0:
         raise ValueError(
-            f"The input dataframe is empty. Please make sure that it at least has columns 'dataset' and 'path' and a row containing appropriate values corresponding to those columns."
+            "The input dataframe is empty. Please make sure that it at least "
+            "has columns 'dataset' and 'path' with appropriate values."
         )
     else:
         print(f"Found {db_length} files to download.")
@@ -471,7 +524,7 @@ def download_data(db, n_jobs=2, save_to=None):
     db_columns = db.columns.tolist()
     if "dataset" not in db_columns or "path" not in db_columns:
         raise ValueError(
-            f"The input dataframe should have columns 'dataset' and 'path' and a row containing appropriate values corresponding to those columns."
+            "The input dataframe must have columns 'dataset' and 'path'."
         )
 
     # get data type from db
@@ -479,6 +532,7 @@ def download_data(db, n_jobs=2, save_to=None):
     # connect to ebrains dataset
     print("... Fetching token and connecting to EBRAINS ...")
     connector = _connect_ebrains(data_type)
+
     # set the save directory
     save_to = _create_root_dir(save_to)
     # file to track downloaded file names and times
@@ -486,31 +540,37 @@ def download_data(db, n_jobs=2, save_to=None):
     # get the file names as they are on ebrains
     src_file_names, dst_file_names = get_file_paths(db, save_to_dir=save_to)
 
-    # helper to process the parallel download
-    def _download_and_update_progress(src_file, dst_file, connector):
-        try:
-            file_name = _download_file(src_file, dst_file, connector)
-            file_time = datetime.now()
-            CACHE.run_maintenance()  # keep cache < 2GB
-            return file_name, file_time
-        except Exception as e:
-            raise (f"Error downloading {src_file}. Error: {e}")
-
     # download finally
     print(f"\n...Starting download of {len(src_file_names)} files...")
-    results = Parallel(n_jobs=n_jobs, backend="threading", verbose=10)(
-        delayed(_download_and_update_progress)(src_file, dst_file, connector)
-        for src_file, dst_file in zip(src_file_names, dst_file_names)
-    )
 
-    # update the local database
-    results = [res for res in results if res[0] is not None]
-    if len(results) == 0:
-        raise RuntimeError(f"No files downloaded ! Please try again.")
-    download_details = _update_local_db(local_db_file, results)
-    print(
-        f"Downloaded requested files from IBC {data_type} dataset. See "
-        f"{local_db_file} for details.\n"
+    failed_files = []
+    download_details = None
+
+    with tqdm(
+        zip(src_file_names, dst_file_names),
+        total=len(src_file_names),
+        desc=f"Downloading {data_type}",
+        unit="file",
+    ) as pbar:
+        for src_file, dst_file in pbar:
+            try:
+                file_name = _download_file(src_file, dst_file, connector)
+                download_details = _update_local_db(
+                    local_db_file, file_name, datetime.now()
+                )
+            except (RuntimeError, OSError, ValueError) as e:
+                tqdm.write(f"ERROR: skipping {src_file}: {e}")
+                failed_files.append(src_file)
+
+    if failed_files:
+        tqdm.write(
+            f"\nWarning: {len(failed_files)}/{len(src_file_names)} files failed to download:\n"
+            + "\n".join(failed_files)
+        )
+
+    tqdm.write(
+        f"Downloaded requested files from IBC {data_type} dataset. "
+        f"See {local_db_file} for details.\n"
     )
 
     # clean up the cache


### PR DESCRIPTION
This PR is for the transition from siibra's EbrainsHdgConnector to [ebrains-drive](https://ebrains.eu/data-tools-services/tools/ebrains-drive) to access IBC files from the command line.
This first commit updates list of files for volume maps repo, version 3.
There was a problem with the listing all the files available in Ebrains for each collection, we were experiencing a data size limit.
The script modified now uses ebrains_drive's `BucketApiClient` to get available data in a given collection.